### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
 # IOGRetranslation
+
+ILLUSION OF GAIA / ILLUSION OF TIME / GAIA GENSOUKI
+ENGLISH RETRANSLATION DEMO V0.1
+Copyright 2024 by GaiaLabs
+https://github.com/Azarem/IOGRetranslation
+https://github.com/Azarem/GaiaLabs
+
+TABLE OF CONTENTS
+
+1.) About the Project
+2.) Application Instructions
+3.) Special Thanks
+
+
+---------------------
+1.) About the Project
+---------------------
+
+In September of 1994, Illusion of Gaia made its North American debut. The story was notable for being much darker than the other RPGs Nintendo was allowing at the time. Despite a softening of the themes, the plot went to dark and intriguing places and left players with much to think about. Unfortunately, the localization was also often incomprehensible, with transitions between first and third person narrative that were difficult to follow. 
+
+We all knew there had to be more and when Resetera forum member L Thammy shared his translation journey with us in 2020, it became evident just how much more. Translating the original Japanese release, Gaia Gensouki, L Thammy gave us an inside look at what the translation process was like while providing us with a more accurate translation of the classic. Please do read the original thread or follow the youtube playlist if you have time!
+
+https://www.resetera.com/threads/lets-play-illusion-of-gaia-but-in-japanese-gaia-gensouki-retranslation-attempt.171584/
+
+https://www.youtube.com/playlist?list=PLoqdJOVga77Bp2FnXfnrf8KhPoVuF1Xeh
+
+Thirty years have passed and it's been a long ride getting to this point, but thankfully, L Thammy was kind enough to allow his translation to be used for a long-awaited re-localization. GaiaLabs could not be any more proud to be releasing a demo for Illusion of Gaia's 30th Anniversary that goes through South Cape. The demo patch can be downloaded from the project's github: https://github.com/Azarem/IOGRetranslation.
+
+
+----------------------------
+2.) Application Instructions
+----------------------------
+
+This is a BPS patch for Illusion of Gaia which replaces the original localization's script for South Cape with L Thammy's retranlation. In addition, the patch decompresses all the assets in the game, while providing an expanded ROM with available space. As a result, loading times are extremely fast! A handful of ASM patches are used to modify the loading process to support faster screen transitions by completely bypassing the decompression steps.
+
+This is a proof-of-concept ROM that *should* be fully playable, but as of this patch version, the retranslation only goes through the first South Cape segment. The decompressed ROM takes about 3MB of space, with 1MB of free space in banks $30 - $3F. You could potentially use this ROM to insert new graphics etc in a raw format, bypassing the need for a compressor, while also enjoying a more seamless gameplay experience.
+
+To use this patch, download FLIPS, Beat, or use the Online Rom Patcher:
+FLIPS - https://www.romhacking.net/utilities/1040/
+Beat - https://www.romhacking.net/utilities/893/
+Online Patcher - https://www.romhacking.net/patch/
+Online Patcher Alt. - https://www.marcrobledo.com/RomPatcher.js/
+
+Tested on original hardware. Please report any bugs on Github.
+
+ROM / ISO Information:
+Database match: Illusion of Gaia (USA)
+Database: No-Intro: Super Nintendo Entertainment System (v. 20210222-050638)
+File/ROM SHA-1: 38DE0C84DD2BC3BDFC0A3D7AB0220C79B70887C3
+File/ROM CRC32: 1C3848C0
+
+
+------------------
+3.) Special Thanks
+------------------
+
+To L Thammy, who graciously allowed us to use his translation as part of the project.


### PR DESCRIPTION
# IOGRetranslation

ILLUSION OF GAIA / ILLUSION OF TIME / GAIA GENSOUKI
ENGLISH RETRANSLATION DEMO V0.1
Copyright 2024 by GaiaLabs
https://github.com/Azarem/IOGRetranslation
https://github.com/Azarem/GaiaLabs

TABLE OF CONTENTS

1.) About the Project
2.) Application Instructions
3.) Special Thanks


---------------------
1.) About the Project
---------------------

In September of 1994, Illusion of Gaia made its North American debut. The story was notable for being much darker than the other RPGs Nintendo was allowing at the time. Despite a softening of the themes, the plot went to dark and intriguing places and left players with much to think about. Unfortunately, the localization was also often incomprehensible, with transitions between first and third person narrative that were difficult to follow. 

We all knew there had to be more and when Resetera forum member L Thammy shared his translation journey with us in 2020, it became evident just how much more. Translating the original Japanese release, Gaia Gensouki, L Thammy gave us an inside look at what the translation process was like while providing us with a more accurate translation of the classic. Please do read the original thread or follow the youtube playlist if you have time!

https://www.resetera.com/threads/lets-play-illusion-of-gaia-but-in-japanese-gaia-gensouki-retranslation-attempt.171584/

https://www.youtube.com/playlist?list=PLoqdJOVga77Bp2FnXfnrf8KhPoVuF1Xeh

Thirty years have passed and it's been a long ride getting to this point, but thankfully, L Thammy was kind enough to allow his translation to be used for a long-awaited re-localization. GaiaLabs could not be any more proud to be releasing a demo for Illusion of Gaia's 30th Anniversary that goes through South Cape. The demo patch can be downloaded from the project's github: https://github.com/Azarem/IOGRetranslation.


----------------------------
2.) Application Instructions
----------------------------

This is a BPS patch for Illusion of Gaia which replaces the original localization's script for South Cape with L Thammy's retranlation. In addition, the patch decompresses all the assets in the game, while providing an expanded ROM with available space. As a result, loading times are extremely fast! A handful of ASM patches are used to modify the loading process to support faster screen transitions by completely bypassing the decompression steps.

This is a proof-of-concept ROM that *should* be fully playable, but as of this patch version, the retranslation only goes through the first South Cape segment. The decompressed ROM takes about 3MB of space, with 1MB of free space in banks $30 - $3F. You could potentially use this ROM to insert new graphics etc in a raw format, bypassing the need for a compressor, while also enjoying a more seamless gameplay experience.

To use this patch, download FLIPS, Beat, or use the Online Rom Patcher:
FLIPS - https://www.romhacking.net/utilities/1040/
Beat - https://www.romhacking.net/utilities/893/
Online Patcher - https://www.romhacking.net/patch/
Online Patcher Alt. - https://www.marcrobledo.com/RomPatcher.js/

Tested on original hardware. Please report any bugs on Github.

ROM / ISO Information:
Database match: Illusion of Gaia (USA)
Database: No-Intro: Super Nintendo Entertainment System (v. 20210222-050638)
File/ROM SHA-1: 38DE0C84DD2BC3BDFC0A3D7AB0220C79B70887C3
File/ROM CRC32: 1C3848C0


------------------
3.) Special Thanks
------------------

To L Thammy, who graciously allowed us to use his translation as part of the project.